### PR TITLE
Update stairsplus modname for pavement_brick, fix aliases

### DIFF
--- a/paving.lua
+++ b/paving.lua
@@ -37,13 +37,14 @@ minetest.register_craft({
 
 
 if minetest.get_modpath("moreblocks") then
-	stairsplus:register_all("castle", "pavement_brick", "castle_masonry:pavement_brick", {
+	stairsplus:register_all("castle_masonry", "pavement_brick", "castle_masonry:pavement_brick", {
 		description = S("Pavement Brick"),
 		tiles = {"castle_pavement_brick.png"},
 		groups = {cracky=2, not_in_creative_inventory=1},
 		sounds = default.node_sound_stone_defaults(),
 		sunlight_propagates = true,
 	})
+	stairsplus:register_alias_all("castle", "pavement_brick", "castle_masonry", "pavement_brick")
 elseif minetest.get_modpath("stairs") then
 	stairs.register_stair_and_slab("pavement_brick", "castle_masonry:pavement_brick",
 		{cracky=2},

--- a/stone_wall.lua
+++ b/stone_wall.lua
@@ -102,8 +102,8 @@ if minetest.get_modpath("moreblocks") then
 		sunlight_propagates = true,
 	})
 	
-	stairsplus:register_stair_alias("castle", "stonewall", "castle_masonry", "stonewall")
-	stairsplus:register_stair_alias("castle", "rubble", "castle_masonry", "rubble")
+	stairsplus:register_alias_all("castle", "stonewall", "castle_masonry", "stonewall")
+	stairsplus:register_alias_all("castle", "rubble", "castle_masonry", "rubble")
 
 elseif minetest.get_modpath("stairs") then
 	stairs.register_stair_and_slab("stonewall", "castle_masonry:stonewall",
@@ -159,7 +159,7 @@ if minetest.get_modpath("moreblocks") then
 		sunlight_propagates = true,
 	})
 
-	stairsplus:register_stair_alias("castle", "dungeon_stone", "castle_masonry", "dungeon_stone")
+	stairsplus:register_alias_all("castle", "dungeon_stone", "castle_masonry", "dungeon_stone")
 	
 elseif minetest.get_modpath("stairs") then
 	stairs.register_stair_and_slab("dungeon_stone", "castle_masonry:dungeon_stone",


### PR DESCRIPTION
Change the stairsplus modname for pavement_brick from "castle" to
"castle_masonry"

Register aliases for all stairsplus shapes, not just stairs.