### PR TITLE
MineClonia `mcl_trees` support

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -71,11 +71,16 @@ if minetest.get_modpath("mcl_core") then
 	register_material({name="cobble", desc=S("Cobble"), craft_material="group:cobble", composition_material="mcl_core:cobble"}, true)
 	register_material({name="stonebrick", desc=S("Stonebrick"), craft_material="mcl_core:stonebrick"}, true)
 	register_material({name="stone", desc=S("Stone"), craft_material="group:stone", composition_material="mcl_core:stone"}, true)
-	register_material({name="wood", desc=S("Wood"), craft_material="group:wood", composition_material="mcl_core:wood"})
 	register_material({name="ice", desc=S("Ice"), craft_material="mcl_core:ice"})
 	register_material({name="snow", desc=S("Snow"), craft_material="mcl_core:snowblock"})
 	register_material({name="sandstone", desc=S("Sandstone"), craft_material="mcl_core:sandstone"}, true)
 	register_material({name="redsandstone", desc=S("Red Sandstone"), craft_material="mcl_core:redsandstone"}, true)
+end
+-- wood ids are different in MineClonia and Mineclone2
+if minetest.get_modpath("mcl_trees") then
+	register_material({name="wood", desc=S("Wood"), craft_material="group:wood", composition_material="mcl_trees:wood_oak"})
+elseif minetest.get_modpath("mcl_core") then
+	register_material({name="wood", desc=S("Wood"), craft_material="group:wood", composition_material="mcl_core:wood"})
 end
 if minetest.get_modpath("mcl_nether") then
 	register_material({name="quartz", desc=S("Quartz"), craft_material="mcl_nether:quartz_block"}, true)

--- a/init.lua
+++ b/init.lua
@@ -76,7 +76,7 @@ if minetest.get_modpath("mcl_core") then
 	register_material({name="sandstone", desc=S("Sandstone"), craft_material="mcl_core:sandstone"}, true)
 	register_material({name="redsandstone", desc=S("Red Sandstone"), craft_material="mcl_core:redsandstone"}, true)
 end
--- wood ids are different in MineClonia and Mineclone2
+-- wood ids are different in MineClonia and Mineclone2, mcl_trees is part of MineClonia
 if minetest.get_modpath("mcl_trees") then
 	register_material({name="wood", desc=S("Wood"), craft_material="group:wood", composition_material="mcl_trees:wood_oak"})
 elseif minetest.get_modpath("mcl_core") then

--- a/mod.conf
+++ b/mod.conf
@@ -1,6 +1,6 @@
 name = castle_masonry
 depends =
-optional_depends = default, mcl_core, mcl_sounds, mcl_nether, mcl_deepslate, mcl_blackstone, mcl_stairs, moreblocks, stairs, building_blocks, asphalt, streets
+optional_depends = default, mcl_core, mcl_sounds, mcl_nether, mcl_deepslate, mcl_blackstone, mcl_stairs, mcl_trees, moreblocks, stairs, building_blocks, asphalt, streets
 description = """
 This is a mod all about creating castles and castle dungeons. 
 Many of the nodes are used for the outer-walls or dungeons.


### PR DESCRIPTION
Wood IDs are different in MineClonia and Mineclone2

MineClonia rewrite woods mod and call it `mcl_trees`